### PR TITLE
Overwrite card rates

### DIFF
--- a/lib/app/battle/functions/damage.dart
+++ b/lib/app/battle/functions/damage.dart
@@ -171,12 +171,13 @@ class Damage {
         }
       }
 
+      final overwriteRates = currentCard.cardDetail.overwriteRates?.getOrNull(currentCard.overwriteRatesIndex);
       final damageParameters = DamageParameters()
         ..attack = activator.atk + currentCard.cardStrengthen
         ..totalHits = Maths.sum(currentCard.cardDetail.hitsDistribution)
         ..damageRate = currentCard.isTD
             ? dataVals.Value! + hpRatioDamageLow + hpRatioDamageHigh
-            : currentCard.cardDetail.damageRate ?? 1000
+            : overwriteRates?.damageRate ?? currentCard.cardDetail.damageRate ?? 1000
         ..damageRateModifier = getDamageRateModifier(battleData, currentCard, target)
         ..npSpecificAttackRate = specificAttackRate
         ..attackerClass = activator.logicalClassId
@@ -227,7 +228,7 @@ class Damage {
         atkNpParameters
           ..attackerNpCharge = currentCard.npGain
           ..defenderNpRate = target.enemyTdRate
-          ..cardAttackNpRate = currentCard.cardDetail.attackNpRate ?? 1000
+          ..cardAttackNpRate = overwriteRates?.attackNpRate ?? currentCard.cardDetail.attackNpRate ?? 1000
           ..isNp = currentCard.isTD
           ..chainPos = chainPos
           ..currentCardType = currentCard.cardType
@@ -251,7 +252,7 @@ class Damage {
         starParameters
           ..attackerStarGen = activator.starGen
           ..defenderStarRate = target.enemyStarRate
-          ..cardDropStarRate = currentCard.cardDetail.dropStarRate ?? 1000
+          ..cardDropStarRate = overwriteRates?.dropStarRate ?? currentCard.cardDetail.dropStarRate ?? 1000
           ..isNp = currentCard.isTD
           ..chainPos = chainPos
           ..currentCardType = currentCard.cardType
@@ -275,7 +276,7 @@ class Damage {
         defNpParameters
           ..defenderNpGainRate = target.defenceNpGain
           ..attackerNpRate = activator.enemyTdAttackRate
-          ..cardDefNpRate = currentCard.cardDetail.defenseNpRate ?? 1000
+          ..cardDefNpRate = overwriteRates?.defenseNpRate ?? currentCard.cardDetail.defenseNpRate ?? 1000
           ..npGainBuff = await target.getBuffValue(
             battleData,
             BuffAction.dropNp,

--- a/lib/app/battle/models/svt_entity.dart
+++ b/lib/app/battle/models/svt_entity.dart
@@ -614,22 +614,21 @@ class BattleServantData {
       final cardType = checkOverwriteSvtCardType(changeCardType ?? cards[index]);
       final detail = niceSvt!.cardDetails[cardType];
       if (detail == null) continue;
-      final card = CommandCardData(this, cardType, detail, index)
-        ..isTD = false
-        ..npGain = getNPGain(cardType)
-        ..traits = ConstData.cardInfo[cardType]!.values.first.individuality.toList();
 
-      if (isCardInDeck) {
-        // enemy weak+strength 6 cards
-        card
-          ..cardStrengthen = playerSvtData!.cardStrengthens.getOrNull(index) ?? 0
-          ..commandCode = playerSvtData!.commandCodes.getOrNull(index);
-      }
-      if (cardType.isWeak()) {
-        card.critical = false;
-      } else if (cardType.isStrength()) {
-        card.critical = true;
-      }
+      final card = CommandCardData(
+        svtId: svtId,
+        svtLimit: limitCount,
+        uniqueId: uniqueId,
+        cardType: cardType,
+        cardDetail: detail,
+        cardIndex: index,
+        isTD: false,
+        npGain: getNPGain(cardType),
+        traits: ConstData.cardInfo[cardType]!.values.first.individuality.toList(),
+        commandCode: isCardInDeck ? playerSvtData!.commandCodes.getOrNull(index) : null,
+        cardStrengthen: isCardInDeck ? playerSvtData!.cardStrengthens.getOrNull(index) ?? 0 : 0,
+        critical: cardType.isStrength(),
+      );
 
       builtCards.add(card);
     }
@@ -641,21 +640,23 @@ class BattleServantData {
       final _td = niceEnemy!.noblePhantasm.noblePhantasm;
       if (_td == null) return null;
       return CommandCardData(
-          this,
-          _td.card,
-          CardDetail(
-            attackIndividuality: _td.individuality.toList(),
-            hitsDistribution: _td.damage,
-            attackType: _td.damageType == TdEffectFlag.attackEnemyAll
-                ? CommandCardAttackType.all
-                : CommandCardAttackType.one,
-          ),
-          -1,
-        )
-        ..td = _td
-        ..isTD = true
-        ..npGain = 0
-        ..traits = _td.individuality.toList();
+        svtId: svtId,
+        svtLimit: limitCount,
+        uniqueId: uniqueId,
+        cardType: _td.card,
+        cardDetail: CardDetail(
+          attackIndividuality: _td.individuality.toList(),
+          hitsDistribution: _td.damage,
+          attackType: _td.damageType == TdEffectFlag.attackEnemyAll
+              ? CommandCardAttackType.all
+              : CommandCardAttackType.one,
+        ),
+        cardIndex: -1,
+        td: _td,
+        isTD: true,
+        npGain: 0,
+        traits: _td.individuality.toList(),
+      );
     }
 
     final currentNP = getCurrentNP();
@@ -667,11 +668,18 @@ class BattleServantData {
           : CommandCardAttackType.one,
     );
 
-    return CommandCardData(this, currentNP?.svt.card ?? CardType.none, cardDetail, -1)
-      ..isTD = true
-      ..td = currentNP
-      ..npGain = currentNP?.npGain.np[playerSvtData!.tdLv - 1] ?? 0
-      ..traits = currentNP?.individuality ?? [];
+    return CommandCardData(
+      svtId: svtId,
+      svtLimit: limitCount,
+      uniqueId: uniqueId,
+      cardType: currentNP?.svt.card ?? CardType.none,
+      cardDetail: cardDetail,
+      cardIndex: -1,
+      isTD: true,
+      td: currentNP,
+      npGain: currentNP?.npGain.np[playerSvtData!.tdLv - 1] ?? 0,
+      traits: currentNP?.individuality ?? [],
+    );
   }
 
   Future<CommandCardData?> getCounterCard(final BattleData battleData) async {
@@ -700,22 +708,36 @@ class BattleServantData {
             : CommandCardAttackType.one,
       );
 
-      return CommandCardData(this, td.svt.card, cardDetail, -1)
-        ..isTD = true
-        ..td = td
-        ..counterBuff = buff
-        ..npGain = td.npGain.np[tdLv - 1]
-        ..traits = td.individuality;
+      return CommandCardData(
+        svtId: svtId,
+        svtLimit: limitCount,
+        uniqueId: uniqueId,
+        cardType: td.svt.card,
+        cardDetail: cardDetail,
+        cardIndex: -1,
+        isTD: true,
+        td: td,
+        counterBuff: buff,
+        npGain: td.npGain.np[tdLv - 1],
+        traits: td.individuality,
+      );
     } else if (buff.vals.UseAttack == 1) {
       final cardId = buff.vals.CounterId ?? 0;
       final cardType = CardType.fromId(cardId);
       final cardDetail = niceSvt?.cardDetails[cardType];
       if (cardType == null || cardDetail == null) return null;
-      return CommandCardData(this, cardType, cardDetail, -1)
-        ..isTD = false
-        ..counterBuff = buff
-        ..npGain = getNPGain(cardType)
-        ..traits = ConstData.cardInfo[cardType]?.values.first.individuality.toList() ?? [];
+      return CommandCardData(
+        svtId: svtId,
+        svtLimit: limitCount,
+        uniqueId: uniqueId,
+        cardType: cardType,
+        cardDetail: cardDetail,
+        cardIndex: -1,
+        isTD: false,
+        counterBuff: buff,
+        npGain: getNPGain(cardType),
+        traits: ConstData.cardInfo[cardType]?.values.first.individuality.toList() ?? [],
+      );
     } else {
       return null;
     }
@@ -730,10 +752,17 @@ class BattleServantData {
     final detail = niceSvt!.cardDetails[cardType];
     if (detail == null) return null;
 
-    return CommandCardData(this, cardType, detail, -1)
-      ..isTD = false
-      ..npGain = getNPGain(cardType)
-      ..traits = ConstData.cardInfo[cardType]!.values.first.individuality.toList();
+    return CommandCardData(
+      svtId: svtId,
+      svtLimit: limitCount,
+      uniqueId: uniqueId,
+      cardType: cardType,
+      cardDetail: detail,
+      cardIndex: -1,
+      isTD: false,
+      npGain: getNPGain(cardType),
+      traits: ConstData.cardInfo[cardType]!.values.first.individuality.toList(),
+    );
   }
 
   CardType checkOverwriteSvtCardType(final CardType baseCardType) {

--- a/lib/app/modules/battle/simulation/combat_action_selector.dart
+++ b/lib/app/modules/battle/simulation/combat_action_selector.dart
@@ -523,9 +523,16 @@ class _EnemyCombatActionSelectorState extends State<EnemyCombatActionSelector> {
             buildRadio(
               title: Text(name),
               onSelected: () async {
-                final cardData = CommandCardData(enemy, cardType, detail, 1)
-                  ..isTD = false
-                  ..traits = ConstData.cardInfo[cardType]?[1]?.individuality.toList() ?? [];
+                final cardData = CommandCardData(
+                  svtId: enemy.svtId,
+                  svtLimit: enemy.limitCount,
+                  uniqueId: enemy.uniqueId,
+                  cardType: cardType,
+                  cardDetail: detail,
+                  cardIndex: 1,
+                  isTD: false,
+                  traits: ConstData.cardInfo[cardType]?[1]?.individuality.toList() ?? [],
+                );
                 if (cardType.isQAB()) {
                   cardData.critical = critical;
                 } else if (cardType.isStrength()) {


### PR DESCRIPTION
**Description**
Added overwrite card rates logic upon card selection.

**Extra card when kills the first target**
<img width="652" height="665" alt="image" src="https://github.com/user-attachments/assets/2e3ec14a-976d-47a3-9e25-16c389dc163a" />

**Extra card when only one target**
<img width="648" height="661" alt="image" src="https://github.com/user-attachments/assets/6d5f685c-6743-4966-aeb2-e496d5a61c35" />
