### PR TITLE
Fix NA login game top refresh

### DIFF
--- a/lib/models/faker/jp/agent.dart
+++ b/lib/models/faker/jp/agent.dart
@@ -23,7 +23,7 @@ class FakerAgentJP extends FakerAgent<FRequestJP, AutoLoginDataJP, NetworkManage
   Future<FResponse> gamedataTop({bool checkAppUpdate = true}) async {
     final tops = await AtlasApi.gametopsRaw(expireAfter: Duration.zero);
     if (tops != null) {
-      network.gameTop.updateFrom(tops.jp);
+      network.gameTop = tops.of(user.region).copy();
     }
     final regionInfo = await AtlasApi.regionInfo(region: user.region);
     if (regionInfo != null) {


### PR DESCRIPTION
Fixes #176.

   `FakerAgentJP` is used for both JP and NA login flows, but `gamedataTop()` refreshed `network.gameTop` from `tops.jp` unconditionally:

   ```dart
   network.gameTop.updateFrom(tops.jp);
 ```
 
 For NA auth import/login, this could leave the NA request using JP dataVer / dateVer, which caused the NA server to respond with:

 ```text
   resCode=89
   action=data_update
 ```

 Observed failing NA /login/top request:

 ```text
   host: game.fate-go.us
   dataVer=2550
   dateVer=1778230800
 ```

 After selecting the gameTop by the user's region:

 ```dart
   network.gameTop = tops.of(user.region).copy();
 ```

 the NA request used the expected NA values:

 ```text
   dataVer=859
   dateVer=1778212800
 ```

 and /login/top returned:

 ```text
   resCode=00
   nid=login
 ```

 Validated with:

 ```sh
   flutter analyze lib/models/faker/jp/agent.dart
 ```

 ```